### PR TITLE
User convert

### DIFF
--- a/grouper/entities/group.py
+++ b/grouper/entities/group.py
@@ -2,7 +2,8 @@ from datetime import timedelta
 from typing import NamedTuple
 
 Group = NamedTuple(
-    "Group", [
+    "Group",
+    [
         ("id", int),
         ("name", str),
         ("contact_email", str),
@@ -11,9 +12,10 @@ Group = NamedTuple(
         ("canjoin", bool),
         ("require_clickthru", bool),
         ("auto_expire", timedelta),
-        ("audit_id", int)
-    ]
+        ("audit_id", int),
+    ],
 )
+
 
 class GroupNotFoundException(Exception):
     """Attempt to operate on a group not found in the storage layer."""

--- a/grouper/entities/group.py
+++ b/grouper/entities/group.py
@@ -1,0 +1,16 @@
+from datetime import timedelta
+from typing import NamedTuple
+
+Group = NamedTuple(
+    "Group", [
+        ("id", int),
+        ("name", str),
+        ("contact_email", str),
+        ("description", str),
+        ("enabled", bool),
+        ("canjoin", bool),
+        ("require_clickthru", bool),
+        ("auto_expire", timedelta),
+        ("audit_id", int)
+    ]
+)

--- a/grouper/entities/group.py
+++ b/grouper/entities/group.py
@@ -14,3 +14,11 @@ Group = NamedTuple(
         ("audit_id", int)
     ]
 )
+
+class GroupNotFoundException(Exception):
+    """Attempt to operate on a group not found in the storage layer."""
+
+    def __init__(self, name):
+        # type: (str) -> None
+        msg = "Group {} not found".format(name)
+        super(GroupNotFoundException, self).__init__(msg)

--- a/grouper/entities/group.py
+++ b/grouper/entities/group.py
@@ -1,22 +1,3 @@
-from datetime import timedelta
-from typing import NamedTuple
-
-Group = NamedTuple(
-    "Group",
-    [
-        ("id", int),
-        ("name", str),
-        ("contact_email", str),
-        ("description", str),
-        ("enabled", bool),
-        ("canjoin", bool),
-        ("require_clickthru", bool),
-        ("auto_expire", timedelta),
-        ("audit_id", int),
-    ],
-)
-
-
 class GroupNotFoundException(Exception):
     """Attempt to operate on a group not found in the storage layer."""
 

--- a/grouper/entities/group_request.py
+++ b/grouper/entities/group_request.py
@@ -18,3 +18,12 @@ UserGroupRequest = NamedTuple(
         ("status", GroupRequestStatus),
     ],
 )
+
+
+class UserGroupRequestNotFoundException(Exception):
+    """Attempt to operate on a UserGroupRequest not found in the storage layer."""
+
+    def __init__(self, request):
+        # type: (UserGroupRequest) -> None
+        msg = "Group membership request {} not found".format(request.id)
+        super(UserGroupRequestNotFoundException, self).__init__(msg)

--- a/grouper/entities/service_account.py
+++ b/grouper/entities/service_account.py
@@ -1,11 +1,3 @@
-from typing import NamedTuple
-
-ServiceAccount = NamedTuple(
-    "ServiceAccount",
-    [("id", int), ("name", str), ("enabled", bool), ("description", str), ("machine_set", str)],
-)
-
-
 class ServiceAccountNotFoundException(Exception):
     """Attempt to operate on a service account not found in the storage layer."""
 
@@ -13,12 +5,3 @@ class ServiceAccountNotFoundException(Exception):
         # type: (str) -> None
         msg = "Service account {} not found".format(name)
         super(ServiceAccountNotFoundException, self).__init__(msg)
-
-
-class ServiceAccountHasOwnerException(Exception):
-    """Attempt to add owner to a service account that already has an owner."""
-
-    def __init__(self, name, group_id):
-        # type: (str, int) -> None
-        msg = "Service account {} already has an owner (id {})".format(name, group_id)
-        super(ServiceAccountHasOwnerException, self).__init__(msg)

--- a/grouper/entities/service_account.py
+++ b/grouper/entities/service_account.py
@@ -17,3 +17,11 @@ class ServiceAccountNotFoundException(Exception):
         # type: (str) -> None
         msg = "Service account {} not found".format(name)
         super(ServiceAccountNotFoundException, self).__init__(msg)
+
+class ServiceAccountHasOwnerException(Exception):
+    """Attempt to add owner to a service account that already has an owner."""
+
+    def __init__(self, name, group_id):
+        # type: (str, int) -> None
+        msg = "Service account {} already has an owner (id {})".format(name, group_id)
+        super(ServiceAccountHasOwnerException, self).__init__(msg)

--- a/grouper/entities/service_account.py
+++ b/grouper/entities/service_account.py
@@ -1,14 +1,10 @@
 from typing import NamedTuple
 
 ServiceAccount = NamedTuple(
-    "ServiceAccount", [
-        ("id", int),
-        ("name", str),
-        ("enabled", bool),
-        ("description", str),
-        ("machine_set", str)
-    ]
+    "ServiceAccount",
+    [("id", int), ("name", str), ("enabled", bool), ("description", str), ("machine_set", str)],
 )
+
 
 class ServiceAccountNotFoundException(Exception):
     """Attempt to operate on a service account not found in the storage layer."""
@@ -17,6 +13,7 @@ class ServiceAccountNotFoundException(Exception):
         # type: (str) -> None
         msg = "Service account {} not found".format(name)
         super(ServiceAccountNotFoundException, self).__init__(msg)
+
 
 class ServiceAccountHasOwnerException(Exception):
     """Attempt to add owner to a service account that already has an owner."""

--- a/grouper/entities/service_account.py
+++ b/grouper/entities/service_account.py
@@ -1,0 +1,19 @@
+from typing import NamedTuple
+
+ServiceAccount = NamedTuple(
+    "ServiceAccount", [
+        ("id", int),
+        ("name", str),
+        ("enabled", bool),
+        ("description", str),
+        ("machine_set", str)
+    ]
+)
+
+class ServiceAccountNotFoundException(Exception):
+    """Attempt to operate on a service account not found in the storage layer."""
+
+    def __init__(self, name):
+        # type: (str) -> None
+        msg = "Service account {} not found".format(name)
+        super(ServiceAccountNotFoundException, self).__init__(msg)

--- a/grouper/entities/user.py
+++ b/grouper/entities/user.py
@@ -1,8 +1,7 @@
 from typing import NamedTuple
 
-User = NamedTuple(
-    "User", [("id", int), ("username", str), ("enabled", bool)]
-)
+User = NamedTuple("User", [("id", int), ("username", str), ("enabled", bool)])
+
 
 class UserNotFoundException(Exception):
     """Attempt to operate on a user not found in the storage layer."""

--- a/grouper/entities/user.py
+++ b/grouper/entities/user.py
@@ -1,8 +1,3 @@
-from typing import NamedTuple
-
-User = NamedTuple("User", [("id", int), ("username", str), ("enabled", bool)])
-
-
 class UserNotFoundException(Exception):
     """Attempt to operate on a user not found in the storage layer."""
 
@@ -10,3 +5,30 @@ class UserNotFoundException(Exception):
         # type: (str) -> None
         msg = "User {} not found".format(name)
         super(UserNotFoundException, self).__init__(msg)
+
+
+class UserIsEnabledException(Exception):
+    """Operation failed because user is a member of groups."""
+
+    def __init__(self, name):
+        # type: (str) -> None
+        msg = "User {} is enabled".format(name)
+        super(UserIsEnabledException, self).__init__(msg)
+
+
+class UserIsMemberOfGroupsException(Exception):
+    """Operation failed because user is a member of groups."""
+
+    def __init__(self, name):
+        # type: (str) -> None
+        msg = "User {} is a member of one or more groups".format(name)
+        super(UserIsMemberOfGroupsException, self).__init__(msg)
+
+
+class UserHasPendingRequestsException(Exception):
+    """Operation failed because user has pending requests."""
+
+    def __init__(self, name):
+        # type: (str) -> None
+        msg = "User {} has one or more pending requests".format(name)
+        super(UserHasPendingRequestsException, self).__init__(msg)

--- a/grouper/entities/user.py
+++ b/grouper/entities/user.py
@@ -1,0 +1,13 @@
+from typing import NamedTuple
+
+User = NamedTuple(
+    "User", [("id", int), ("username", str), ("enabled", bool)]
+)
+
+class UserNotFoundException(Exception):
+    """Attempt to operate on a user not found in the storage layer."""
+
+    def __init__(self, name):
+        # type: (str) -> None
+        msg = "User {} not found".format(name)
+        super(UserNotFoundException, self).__init__(msg)

--- a/grouper/repositories/audit_log.py
+++ b/grouper/repositories/audit_log.py
@@ -4,6 +4,9 @@ from typing import TYPE_CHECKING
 from sqlalchemy import desc
 
 from grouper.entities.audit_log_entry import AuditLogEntry
+from grouper.entities.group import GroupNotFoundException
+from grouper.entities.permission import PermissionNotFoundException
+from grouper.entities.user import UserNotFoundException
 from grouper.models.audit_log import AuditLog, AuditLogCategory
 from grouper.models.group import Group
 from grouper.models.permission import Permission
@@ -15,11 +18,6 @@ if TYPE_CHECKING:
     from grouper.usecases.authorization import Authorization
     from typing import List, Optional
 
-
-class UnknownGroupException(Exception):
-    """Group involved in a logged action does not exist."""
-
-    pass
 
 
 class UnknownPermissionException(Exception):
@@ -99,21 +97,21 @@ class AuditLogRepository(object):
         # type: (str) -> int
         group_obj = Group.get(self.session, name=group)
         if not group_obj:
-            raise UnknownGroupException("unknown group {}".format(group))
+            raise GroupNotFoundException(group)
         return group_obj.id
 
     def _id_for_permission(self, permission):
         # type: (str) -> int
         permission_obj = Permission.get(self.session, name=permission)
         if not permission_obj:
-            raise UnknownUserException("unknown permission {}".format(permission))
+            raise PermissionNotFoundException(permission)
         return permission_obj.id
 
     def _id_for_user(self, user):
         # type: (str) -> int
         user_obj = User.get(self.session, name=user)
         if not user_obj:
-            raise UnknownUserException("unknown user {}".format(user))
+            raise UserNotFoundException(user)
         return user_obj.id
 
     def _to_audit_log_entry(self, entry):

--- a/grouper/repositories/audit_log.py
+++ b/grouper/repositories/audit_log.py
@@ -19,7 +19,6 @@ if TYPE_CHECKING:
     from typing import List, Optional
 
 
-
 class UnknownPermissionException(Exception):
     """Permission involved in a logged action does not exist."""
 

--- a/grouper/repositories/audit_log.py
+++ b/grouper/repositories/audit_log.py
@@ -19,18 +19,6 @@ if TYPE_CHECKING:
     from typing import List, Optional
 
 
-class UnknownPermissionException(Exception):
-    """Permission involved in a logged action does not exist."""
-
-    pass
-
-
-class UnknownUserException(Exception):
-    """User involved in a logged action does not exist."""
-
-    pass
-
-
 class AuditLogRepository(object):
     """SQL storage layer for audit log entries."""
 

--- a/grouper/repositories/factory.py
+++ b/grouper/repositories/factory.py
@@ -2,26 +2,18 @@ from typing import TYPE_CHECKING
 
 from grouper.repositories.audit_log import AuditLogRepository
 from grouper.repositories.checkpoint import CheckpointRepository
-from grouper.repositories.group_edge import GraphGroupEdgeRepository, SQLGroupEdgeRepository
+from grouper.repositories.group_edge import GroupEdgeRepository
 from grouper.repositories.group_request import GroupRequestRepository
 from grouper.repositories.permission import GraphPermissionRepository, SQLPermissionRepository
 from grouper.repositories.permission_grant import GraphPermissionGrantRepository
-from grouper.repositories.service_account import (
-    GraphServiceAccountRepository,
-    SQLServiceAccountRepository,
-)
+from grouper.repositories.service_account import ServiceAccountRepository
 from grouper.repositories.transaction import TransactionRepository
-from grouper.repositories.user import GraphUserRepository, SQLUserRepository
+from grouper.repositories.user import UserRepository
 
 if TYPE_CHECKING:
     from grouper.graph import GroupGraph
     from grouper.models.base.session import Session
-    from grouper.repositories.interfaces import (
-        PermissionRepository,
-        PermissionGrantRepository,
-        ServiceAccountRepository,
-        UserRepository,
-    )
+    from grouper.repositories.interfaces import PermissionRepository, PermissionGrantRepository
 
 
 class RepositoryFactory(object):
@@ -41,8 +33,7 @@ class RepositoryFactory(object):
         return CheckpointRepository(self.session)
 
     def create_group_edge_repository(self):
-        sql_group_edge_repository = SQLGroupEdgeRepository(self.session)
-        return GraphGroupEdgeRepository(self.graph, sql_group_edge_repository)
+        return GroupEdgeRepository(self.graph)
 
     def create_group_request_repository(self):
         # type: () -> GroupRequestRepository
@@ -59,18 +50,7 @@ class RepositoryFactory(object):
 
     def create_service_account_repository(self):
         # type: () -> ServiceAccountRepository
-        sql_group_edge_repository = SQLGroupEdgeRepository(self.session)
-        group_edge_repository = GraphGroupEdgeRepository(self.graph, sql_group_edge_repository)
-
-        group_request_repository = GroupRequestRepository(self.session)
-
-        sql_user_repository = SQLUserRepository(
-            self.session, group_edge_repository, group_request_repository
-        )
-        user_repository = GraphUserRepository(self.graph, sql_user_repository)
-
-        sql_service_account_repository = SQLServiceAccountRepository(self.session, user_repository)
-        return GraphServiceAccountRepository(self.graph, sql_service_account_repository)
+        return ServiceAccountRepository(self.session)
 
     def create_transaction_repository(self):
         # type: () -> TransactionRepository
@@ -78,12 +58,4 @@ class RepositoryFactory(object):
 
     def create_user_repository(self):
         # type: () -> UserRepository
-        sql_group_edge_repository = SQLGroupEdgeRepository(self.session)
-        group_edge_repository = GraphGroupEdgeRepository(self.graph, sql_group_edge_repository)
-
-        group_request_repository = GroupRequestRepository(self.session)
-
-        sql_user_repository = SQLUserRepository(
-            self.session, group_edge_repository, group_request_repository
-        )
-        return GraphUserRepository(self.graph, sql_user_repository)
+        return UserRepository(self.session)

--- a/grouper/repositories/factory.py
+++ b/grouper/repositories/factory.py
@@ -5,13 +5,22 @@ from grouper.repositories.checkpoint import CheckpointRepository
 from grouper.repositories.group_request import GroupRequestRepository
 from grouper.repositories.permission import GraphPermissionRepository, SQLPermissionRepository
 from grouper.repositories.permission_grant import GraphPermissionGrantRepository
+from grouper.repositories.service_account import (
+    GraphServiceAccountRepository,
+    SQLServiceAccountRepository,
+)
 from grouper.repositories.transaction import TransactionRepository
-from grouper.repositories.user import UserRepository
+from grouper.repositories.user import GraphUserRepository, SQLUserRepository
 
 if TYPE_CHECKING:
     from grouper.graph import GroupGraph
     from grouper.models.base.session import Session
-    from grouper.repositories.interfaces import PermissionRepository, PermissionGrantRepository
+    from grouper.repositories.interfaces import (
+        PermissionRepository,
+        PermissionGrantRepository,
+        ServiceAccountRepository,
+        UserRepository,
+    )
 
 
 class RepositoryFactory(object):
@@ -43,10 +52,17 @@ class RepositoryFactory(object):
         # type: () -> PermissionGrantRepository
         return GraphPermissionGrantRepository(self.graph)
 
+    def create_service_account_repository(self):
+        # type: () -> ServiceAccountRepository
+        user_repository = SQLUserRepository(self.session)
+        sql_service_account_repository = SQLServiceAccountRepository(self.session, user_repository)
+        return GraphServiceAccountRepository(self.graph, sql_service_account_repository)
+
     def create_transaction_repository(self):
         # type: () -> TransactionRepository
         return TransactionRepository(self.session)
 
     def create_user_repository(self):
         # type: () -> UserRepository
-        return GraphUserRepository(self.session, self.graph)
+        sql_user_repository = SQLUserRepository(self.session)
+        return GraphUserRepository(self.graph, sql_user_repository)

--- a/grouper/repositories/factory.py
+++ b/grouper/repositories/factory.py
@@ -65,11 +65,10 @@ class RepositoryFactory(object):
         group_request_repository = GroupRequestRepository(self.session)
 
         sql_user_repository = SQLUserRepository(
-            self.session,
-            group_edge_repository,
-            group_request_repository) 
+            self.session, group_edge_repository, group_request_repository
+        )
         user_repository = GraphUserRepository(self.graph, sql_user_repository)
-        
+
         sql_service_account_repository = SQLServiceAccountRepository(self.session, user_repository)
         return GraphServiceAccountRepository(self.graph, sql_service_account_repository)
 
@@ -85,7 +84,6 @@ class RepositoryFactory(object):
         group_request_repository = GroupRequestRepository(self.session)
 
         sql_user_repository = SQLUserRepository(
-            self.session,
-            group_edge_repository,
-            group_request_repository) 
+            self.session, group_edge_repository, group_request_repository
+        )
         return GraphUserRepository(self.graph, sql_user_repository)

--- a/grouper/repositories/factory.py
+++ b/grouper/repositories/factory.py
@@ -62,11 +62,13 @@ class RepositoryFactory(object):
         sql_group_edge_repository = SQLGroupEdgeRepository(self.session)
         group_edge_repository = GraphGroupEdgeRepository(self.graph, sql_group_edge_repository)
 
-        sql_user_repository = SQLUserRepository(self.session)
-        user_repository = GraphUserRepository(
-            self.graph,
-            sql_user_repository,
-            group_edge_repository)
+        group_request_repository = GroupRequestRepository(self.session)
+
+        sql_user_repository = SQLUserRepository(
+            self.session,
+            group_edge_repository,
+            group_request_repository) 
+        user_repository = GraphUserRepository(self.graph, sql_user_repository)
         
         sql_service_account_repository = SQLServiceAccountRepository(self.session, user_repository)
         return GraphServiceAccountRepository(self.graph, sql_service_account_repository)
@@ -77,7 +79,13 @@ class RepositoryFactory(object):
 
     def create_user_repository(self):
         # type: () -> UserRepository
-        sql_user_repository = SQLUserRepository(self.session)
         sql_group_edge_repository = SQLGroupEdgeRepository(self.session)
         group_edge_repository = GraphGroupEdgeRepository(self.graph, sql_group_edge_repository)
-        return GraphUserRepository(self.graph, sql_user_repository, group_edge_repository)
+
+        group_request_repository = GroupRequestRepository(self.session)
+
+        sql_user_repository = SQLUserRepository(
+            self.session,
+            group_edge_repository,
+            group_request_repository) 
+        return GraphUserRepository(self.graph, sql_user_repository)

--- a/grouper/repositories/factory.py
+++ b/grouper/repositories/factory.py
@@ -49,4 +49,4 @@ class RepositoryFactory(object):
 
     def create_user_repository(self):
         # type: () -> UserRepository
-        return UserRepository(self.session)
+        return GraphUserRepository(self.session, self.graph)

--- a/grouper/repositories/group_edge.py
+++ b/grouper/repositories/group_edge.py
@@ -1,56 +1,19 @@
 from typing import TYPE_CHECKING
 
-from grouper.repositories.interfaces import GroupEdgeRepository
-
 if TYPE_CHECKING:
     from grouper.graph import GroupGraph
     from grouper.models.base.session import Session
     from typing import List
 
 
-class GraphGroupEdgeRepository(GroupEdgeRepository):
-    """Graph-aware storage layer for group edges.group
+class GroupEdgeRepository(object):
+    """Storage layer for group edges."""
 
-    WARNING: This repository should only be used from other repositories. At higher levels -- the
-    service layer, the use case layer, and the UI layer -- the abstraction should be that there
-    are users and groups, and group edges (membership) is a relationship between those. Thus a
-    service needing to act on the group edges corresponding to a user would call into the user
-    repository (which would in turn call into this repository), and equivalently for a group.
-    """
-
-    def __init__(self, graph, repository):
-        # type: (GroupGraph, GroupEdgeRepository) -> None
+    def __init__(self, graph):
+        # type: (GroupGraph) -> None
         self.graph = graph
-        self.repository = repository
-
-    def add_user_to_group(self, username, groupname, role):
-        # type: (str, str, str) -> None
-        raise NotImplementedError()
 
     def groups_of_user(self, username):
         # type: (str) -> List[str]
         user_details = self.graph.get_user_details(username)
         return [group for group in user_details["groups"]]
-
-
-class SQLGroupEdgeRepository(GroupEdgeRepository):
-    """SQL storage layer for group edges.group
-
-    WARNING: This repository should only be used from other repositories. At higher levels -- the
-    service layer, the use case layer, and the UI layer -- the abstraction should be that there
-    are users and groups, and group edges (membership) are a relationship between those. Thus a
-    service needing to act on the group edges corresponding to a user would call into the user
-    repository (which would in turn call into this repository), and equivalently for a group.
-    """
-
-    def __init__(self, session):
-        # type: (Session) -> None
-        self.session = session
-
-    def add_user_to_group(self, username, groupname, role):
-        # type: (str, str, str) -> None
-        raise NotImplementedError()
-
-    def groups_of_user(self, username):
-        # type: (str) -> List[str]
-        raise NotImplementedError()

--- a/grouper/repositories/group_edge.py
+++ b/grouper/repositories/group_edge.py
@@ -1,0 +1,95 @@
+from typing import TYPE_CHECKING
+
+from grouper.group_member import persist_group_member_changes
+from grouper.models.base.constants import OBJ_TYPES
+from grouper.models.group import Group
+from grouper.models.group_edge import GroupEdge, GROUP_EDGE_ROLES
+from grouper.models.user import User
+from grouper.repositories.interfaces import GroupEdgeRepository
+
+if TYPE_CHECKING:
+    from grouper.graph import GroupGraph
+    from grouper.models.base.session import Session
+    from typing import List
+
+class UnknownGroupException(Exception):
+    """Group involved in a logged action does not exist."""
+    pass
+
+class UnknownUserException(Exception):
+    """User involved in a logged action does not exist."""
+    pass
+
+class GraphGroupEdgeRepository(GroupEdgeRepository):
+    """Graph-aware storage layer for group edges.group
+
+    WARNING: This repository should only be used from other repositories. At higher levels -- the
+    service layer, the use case layer, and the UI layer -- the abstraction should be that there
+    are users and groups, and group edges (membership) is a relationship between those. Thus a
+    service needing to act on the group edges corresponding to a user would call into the user
+    repository (which would in turn call into this repository), and equivalently for a group.
+    """
+
+    def __init__(self, graph, repository):
+        # type: (GroupGraph, GroupEdgeRepository) -> None
+        self.graph = graph
+        self.repository = repository
+
+    def add_user_to_group(self, username, groupname, role):
+        # type: (str, str, str) -> None
+        return self.repository.add_user_to_group(username, groupname, role)
+
+    def groups_of_user(self, username):
+        # type: (str) -> List[str]
+        user_details = self.graph.get_user_details(username)
+        return [group["name"] for group in user_details["groups"]]
+
+
+class SQLGroupEdgeRepository(GroupEdgeRepository):
+    """SQL storage layer for group edges.group
+
+    WARNING: This repository should only be used from other repositories. At higher levels -- the
+    service layer, the use case layer, and the UI layer -- the abstraction should be that there
+    are users and groups, and group edges (membership) are a relationship between those. Thus a
+    service needing to act on the group edges corresponding to a user would call into the user
+    repository (which would in turn call into this repository), and equivalently for a group.
+    """
+
+    def __init__(self, session):
+        # type: (Session) -> None
+        self.session = session
+
+    def add_user_to_group(self, username, groupname, role):
+        # type: (str, str, str) -> None
+        group_id = self._id_for_group(groupname)
+        member_type = OBJ_TYPES["User"]
+        member_id = self._id_for_user(username)
+        role_index = GROUP_EDGE_ROLES.index(role)
+
+        edge = GroupEdge(
+            group_id=group_id,
+            member_type=member_type,
+            member_pk=member_id,
+            expiration=None,
+            active=True,
+            _role=role_index,
+        )
+        edge.add(self.session)
+
+    def groups_of_user(self, username):
+        # type: (str) -> List[str]
+        raise NotImplementedError()
+
+    def _id_for_group(self, groupname):
+        # type: (str) -> int
+        group_obj = Group.get(self.session, name=groupname)
+        if not group_obj:
+            raise UnknownGroupException("unknown group {}".format(groupname))
+        return group_obj.id
+
+    def _id_for_user(self, username):
+        # type: (str) -> int
+        user_obj = User.get(self.session, name=username)
+        if not user_obj:
+            raise UnknownUserException("unknown user {}".format(username))
+        return user_obj.id

--- a/grouper/repositories/interfaces.py
+++ b/grouper/repositories/interfaces.py
@@ -9,26 +9,6 @@ if TYPE_CHECKING:
     from typing import List, Optional
 
 
-class GroupEdgeRepository(object):
-    """Abstract base class for group edge repositories.class
-
-    WARNING: This repository should only be used from other repositories.
-    See repositories/group_edge.py for more details.
-    """
-
-    __metaclass__ = ABCMeta
-
-    @abstractmethod
-    def add_user_to_group(self, username, groupname, role):
-        # type: (str, str, str) -> None
-        pass
-
-    @abstractmethod
-    def groups_of_user(self, username):
-        # type: (str) -> List[str]
-        pass
-
-
 class PermissionRepository(object):
     """Abstract base class for permission repositories."""
 
@@ -63,65 +43,4 @@ class PermissionGrantRepository(object):
     @abstractmethod
     def user_has_permission(self, user, permission):
         # type: (str, str) -> bool
-        pass
-
-
-class ServiceAccountRepository(object):
-    """Abstract base class for service account repositories."""
-
-    __metaclass__ = ABCMeta
-
-    @abstractmethod
-    def assign_service_account_to_group(self, username, groupname):
-        # type: (str, str) -> None
-        pass
-
-    @abstractmethod
-    def enable_service_account(self, name):
-        # type: (str) -> None
-        pass
-
-    @abstractmethod
-    def set_service_account_description(self, name, description):
-        # type: (str, str) -> None
-        pass
-
-    @abstractmethod
-    def set_service_account_mdbset(self, name, mdbset):
-        # type: (str, str) -> None
-        pass
-
-
-class UserRepository(object):
-    """Abstract base class for user repositories."""
-
-    __metaclass__ = ABCMeta
-
-    @abstractmethod
-    def add_user_to_group(self, username, groupname, role):
-        # type: (str, str, str) -> None
-        pass
-
-    @abstractmethod
-    def disable_user(self, username):
-        # type: (str) -> None
-        pass
-
-    @abstractmethod
-    def enable_user(self, username):
-        # type: (str) -> None
-        pass
-
-    @abstractmethod
-    def groups_of_user(self, username):
-        # type: (str) -> List[str]
-        pass
-
-    @abstractmethod
-    def mark_disabled_user_as_service_account(self, username):
-        # type: (str) -> None
-        # WARNING: This function encodes the fact that the user and service account repos
-        # are in fact the same thing, as it assumes that a service account is just a user
-        # that is marked in a special way. This is a temporary breaking of the abstractions
-        # and will have to be cleaned up once the repositories are properly separate.
         pass

--- a/grouper/repositories/interfaces.py
+++ b/grouper/repositories/interfaces.py
@@ -46,17 +46,62 @@ class PermissionGrantRepository(object):
         pass
 
 
+class ServiceAccountRepository(object):
+    """Abstract base class for service account repositories."""
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def assign_service_account_to_group(self, username, groupname):
+        # type: (str, str) -> None
+        pass
+
+    @abstractmethod
+    def enable_service_account(self, name):
+        # type: (str) -> None
+        pass
+
+    @abstractmethod
+    def set_service_account_description(self, name, description):
+        # type: (str, str) -> None
+        pass
+
+    @abstractmethod
+    def set_service_account_mdbset(self, name, mdbset):
+        # type: (str, str) -> None
+        pass
+
+
 class UserRepository(object):
     """Abstract base class for user repositories."""
 
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def disable_user(self, user):
+    def add_user_to_group(self, username, groupname):
+        # type: (str, str) -> None
+        pass
+
+    @abstractmethod
+    def disable_user(self, username):
         # type: (str) -> None
         pass
 
     @abstractmethod
-    def groups_of_user(self, user):
+    def enable_user(self, username):
+        # type: (str) -> None
+        pass
+
+    @abstractmethod
+    def groups_of_user(self, username):
         # type: (str) -> List[str]
+        pass
+
+    @abstractmethod
+    def mark_disabled_user_as_service_account(self, username):
+        # type: (str) -> None
+        # WARNING: This function encodes the fact that the user and service account repos
+        # are in fact the same thing, as it assumes that a service account is just a user
+        # that is marked in a special way. This is a temporary breaking of the abstractions
+        # and will have to be cleaned up once the repositories are properly separate.
         pass

--- a/grouper/repositories/interfaces.py
+++ b/grouper/repositories/interfaces.py
@@ -9,6 +9,26 @@ if TYPE_CHECKING:
     from typing import List, Optional
 
 
+class GroupEdgeRepository(object):
+    """Abstract base class for group edge repositories.class
+
+    WARNING: This repository should only be used from other repositories.
+    See repositories/group_edge.py for more details.
+    """
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def add_user_to_group(self, username, groupname, role):
+        # type: (str, str, str) -> None
+        pass
+
+    @abstractmethod
+    def groups_of_user(self, username):
+        # type: (str) -> List[str]
+        pass
+
+
 class PermissionRepository(object):
     """Abstract base class for permission repositories."""
 
@@ -78,8 +98,8 @@ class UserRepository(object):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def add_user_to_group(self, username, groupname):
-        # type: (str, str) -> None
+    def add_user_to_group(self, username, groupname, role):
+        # type: (str, str, str) -> None
         pass
 
     @abstractmethod

--- a/grouper/repositories/interfaces.py
+++ b/grouper/repositories/interfaces.py
@@ -31,7 +31,7 @@ class PermissionRepository(object):
 
 
 class PermissionGrantRepository(object):
-    """Abstract base class for permission grants."""
+    """Abstract base class for permission grant repositories."""
 
     __metaclass__ = ABCMeta
 
@@ -43,4 +43,20 @@ class PermissionGrantRepository(object):
     @abstractmethod
     def user_has_permission(self, user, permission):
         # type: (str, str) -> bool
+        pass
+
+
+class UserRepository(object):
+    """Abstract base class for user repositories."""
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def disable_user(self, user):
+        # type: (str) -> None
+        pass
+
+    @abstractmethod
+    def groups_of_user(self, user):
+        # type: (str) -> List[str]
         pass

--- a/grouper/repositories/service_account.py
+++ b/grouper/repositories/service_account.py
@@ -1,0 +1,74 @@
+from typing import TYPE_CHECKING
+
+from grouper.entities.service_account import ServiceAccountNotFoundException
+from grouper.models.service_account import ServiceAccount as SQLServiceAccount
+from grouper.repositories.interfaces import UserRepository, ServiceAccountRepository
+
+if TYPE_CHECKING:
+    from grouper.graph import GroupGraph
+    from grouper.models.base.session import Session
+
+class GraphServiceAccountRepository(ServiceAccountRepository):
+    """Graph-aware storage layer for service accounts."""
+
+    def __init__(self, graph, repository):
+        # type: (GroupGraph, ServiceAccountRepository) -> None
+        self.graph = graph
+        self.repository = repository
+
+    def assign_service_account_to_group(self, username, groupname):
+        # type: (str, str) -> None
+        return self.repository.assign_service_account_to_group(username, groupname)
+
+    def enable_service_account(self, name):
+        # type: (str) -> None
+        return self.repository.enable_service_account(name)
+
+    def set_service_account_description(self, name, description):
+        # type: (str, str) -> None
+        return self.repository.set_service_account_description(name, description)
+
+    def set_service_account_mdbset(self, name, mdbset):
+        # type: (str, str) -> None
+        return self.repository.set_service_account_mdbset(name, mdbset)
+
+class SQLServiceAccountRepository(ServiceAccountRepository):
+    """SQL storage layer for service accounts."""
+
+    def __init__(self, session, user_repository):
+        # type: (Session, UserRepository) -> None
+        self.session = session
+        self.user_repository = repository
+
+    def assign_service_account_to_group(self, username, groupname):
+        # type: (str, str) -> None
+        # NOTE: The fact that we have this check that the service account exists and then
+        # never use it is an artifact of the user and service account repositories being the same.user_repository
+        # It can be fixed once the two repositories are properly separate.
+        if not SQLServiceAccount.get(self.session, name=name)
+            raise ServiceAccountNotFoundException(name)
+        return self.user_repository.add_user_to_group(username, groupname)
+
+    def enable_service_account(self, name):
+        # type: (str) -> None
+        # NOTE: The fact that we have this check that the service account exists and then
+        # never use it is an artifact of the user and service account repositories being the same.user_repository
+        # It can be fixed once the two repositories are properly separate.
+        service_account = SQLServiceAccount.get(self.session, name=name)
+        if not service_account:
+            raise ServiceAccountNotFoundException(name)
+        return self.user_repository.enable_user(username)
+
+    def set_service_account_description(self, name, description):
+        # type: (str, str) -> None
+        service_account = SQLServiceAccount.get(self.session, name=name)
+        if not service_account:
+            raise ServiceAccountNotFoundException(name)
+        service_account.description = description
+
+    def set_service_account_mdbset(self, name, mdbset):
+        # type: (str, str) -> None
+        service_account = SQLServiceAccount.get(self.session, name=name)
+        if not service_account:
+            raise ServiceAccountNotFoundException(name)
+        service_account.mdbset = mdbset

--- a/grouper/repositories/service_account.py
+++ b/grouper/repositories/service_account.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from grouper.graph import GroupGraph
     from grouper.models.base.session import Session
 
+
 class GraphServiceAccountRepository(ServiceAccountRepository):
     """Graph-aware storage layer for service accounts."""
 
@@ -38,6 +39,7 @@ class GraphServiceAccountRepository(ServiceAccountRepository):
         # type: (str, str) -> None
         return self.repository.set_service_account_mdbset(name, mdbset)
 
+
 class SQLServiceAccountRepository(ServiceAccountRepository):
     """SQL storage layer for service accounts."""
 
@@ -57,14 +59,13 @@ class SQLServiceAccountRepository(ServiceAccountRepository):
             raise GroupNotFoundException(groupname)
 
         existing_relationship = GroupServiceAccount.get(
-            self.session,
-            service_account_id=service_account.id)
+            self.session, service_account_id=service_account.id
+        )
         if existing_relationship:
             raise ServiceAccountHasOwnerException(name, existing_relationship.group_id)
 
         group_service_account = GroupServiceAccount(
-            group_id=group.id,
-            service_account_id=service_account.id,
+            group_id=group.id, service_account_id=service_account.id
         )
         group_service_account.add(self.session)
 

--- a/grouper/repositories/user.py
+++ b/grouper/repositories/user.py
@@ -3,25 +3,42 @@ from typing import TYPE_CHECKING
 from grouper.entities.user import UserNotFoundException
 from grouper.models.service_account import ServiceAccount as SQLServiceAccount
 from grouper.models.user import User as SQLUser
-from grouper.repositories.interfaces import UserRepository, GroupEdgeRepository
+from grouper.repositories.interfaces import UserRepository
 
 if TYPE_CHECKING:
     from grouper.graph import GroupGraph
     from grouper.models.base.session import Session
+    from grouper.repositories.group_request import GroupRequestRepository
+    from grouper.repositories.interfaces import GroupEdgeRepository
     from typing import List
+
+class UserIsMemberOfGroupsException(Exception):
+    """Operation failed because user is a member of groups."""
+
+    def __init__(self, username):
+        # type: (str) -> None
+        msg = "User {} is a member of one or more groups".format(username)
+        super(UserIsMemberOfGroupsException, self).__init__(msg)
+
+class UserHasPendingRequestsException(Exception):
+    """Operation failed because user has pending requests."""
+
+    def __init__(self, username):
+        # type: (str) -> None
+        msg = "User {} has one or more pending requests".format(username)
+        super(UserHasPendingRequestsException, self).__init__(msg)
 
 class GraphUserRepository(UserRepository):
     """Graph-aware storage layer for users."""
 
-    def __init__(self, graph, repository, group_edge_repository):
-        # type: (GroupGraph, UserRepository, GroupEdgeRepository) -> None
+    def __init__(self, graph, repository):
+        # type: (GroupGraph, UserRepository) -> None
         self.graph = graph
         self.repository = repository
-        self.group_edge_repository = group_edge_repository
 
     def add_user_to_group(self, username, groupname, role):
         # type: (str, str, str) -> None
-        return self.group_edge_repository.add_user_to_group(username, groupname, role)
+        return self.repository.add_user_to_group(username, groupname, role)
 
     def disable_user(self, username):
         # type: (str) -> None
@@ -33,7 +50,7 @@ class GraphUserRepository(UserRepository):
 
     def groups_of_user(self, username):
         # type: (str) -> List[str]
-        return self.group_edge_repository.groups_of_user(username)
+        return self.repository.groups_of_user(username)
 
     def mark_disabled_user_as_service_account(self, username):
         # type: (str) -> None
@@ -42,19 +59,22 @@ class GraphUserRepository(UserRepository):
 class SQLUserRepository(UserRepository):
     """SQL storage layer for users."""
 
-    def __init__(self, session):
-        # type: (Session) -> None
+    def __init__(self, session, group_edge_repository, group_request_repository):
+        # type: (Session, GroupEdgeRepository, GroupRequestRepository) -> None
         self.session = session
+        self.group_edge_repository = group_edge_repository
+        self.group_request_repository = group_request_repository
 
     def add_user_to_group(self, username, groupname, role):
         # type: (str, str, str) -> None
-        raise NotImplementedError()
+        return self.group_edge_repository.add_user_to_group(username, groupname, role)
 
     def disable_user(self, username):
         # type: (str) -> None
         user = SQLUser.get(self.session, name=username)
         if not user:
             raise UserNotFoundException(username)
+
         user.enabled = False
 
     def enable_user(self, username):
@@ -62,17 +82,24 @@ class SQLUserRepository(UserRepository):
         user = SQLUser.get(self.session, name=username)
         if not user:
             raise UserNotFoundException(username)
+
         user.enabled = True
 
     def groups_of_user(self, username):
         # type: (str) -> List[str]
-        raise NotImplementedError()
+        return self.group_edge_repository.groups_of_user(username)
 
     def mark_disabled_user_as_service_account(self, username):
         # type: (str) -> None
         user = SQLUser.get(self.session, name=username)
         if not user:
             raise UserNotFoundException(username)
+
+        if self.groups_of_user(username) != []:
+            raise UserIsMemberOfGroupsException(username)
+
+        if self.group_request_repository.pending_requests_for_user(username) != []:
+            raise UserHasPendingRequestsException(username)
 
         service_account = SQLServiceAccount(
             user_id=user.id,

--- a/grouper/repositories/user.py
+++ b/grouper/repositories/user.py
@@ -3,109 +3,32 @@ from typing import TYPE_CHECKING
 from grouper.entities.user import UserNotFoundException
 from grouper.models.service_account import ServiceAccount as SQLServiceAccount
 from grouper.models.user import User as SQLUser
-from grouper.repositories.interfaces import UserRepository
 
 if TYPE_CHECKING:
     from grouper.graph import GroupGraph
     from grouper.models.base.session import Session
-    from grouper.repositories.group_request import GroupRequestRepository
-    from grouper.repositories.interfaces import GroupEdgeRepository
     from typing import List
 
 
-class UserIsMemberOfGroupsException(Exception):
-    """Operation failed because user is a member of groups."""
+class UserRepository(object):
+    """Storage layer for users."""
 
-    def __init__(self, username):
-        # type: (str) -> None
-        msg = "User {} is a member of one or more groups".format(username)
-        super(UserIsMemberOfGroupsException, self).__init__(msg)
-
-
-class UserHasPendingRequestsException(Exception):
-    """Operation failed because user has pending requests."""
-
-    def __init__(self, username):
-        # type: (str) -> None
-        msg = "User {} has one or more pending requests".format(username)
-        super(UserHasPendingRequestsException, self).__init__(msg)
-
-
-class GraphUserRepository(UserRepository):
-    """Graph-aware storage layer for users."""
-
-    def __init__(self, graph, repository):
-        # type: (GroupGraph, UserRepository) -> None
-        self.graph = graph
-        self.repository = repository
-
-    def add_user_to_group(self, username, groupname, role):
-        # type: (str, str, str) -> None
-        return self.repository.add_user_to_group(username, groupname, role)
-
-    def disable_user(self, username):
-        # type: (str) -> None
-        return self.repository.disable_user(username)
-
-    def enable_user(self, username):
-        # type: (str) -> None
-        return self.repository.enable_user(username)
-
-    def groups_of_user(self, username):
-        # type: (str) -> List[str]
-        return self.repository.groups_of_user(username)
-
-    def mark_disabled_user_as_service_account(self, username):
-        # type: (str) -> None
-        return self.repository.mark_disabled_user_as_service_account(username)
-
-
-class SQLUserRepository(UserRepository):
-    """SQL storage layer for users."""
-
-    def __init__(self, session, group_edge_repository, group_request_repository):
-        # type: (Session, GroupEdgeRepository, GroupRequestRepository) -> None
+    def __init__(self, session):
+        # type: (Session) -> None
         self.session = session
-        self.group_edge_repository = group_edge_repository
-        self.group_request_repository = group_request_repository
 
-    def add_user_to_group(self, username, groupname, role):
-        # type: (str, str, str) -> None
-        return self.group_edge_repository.add_user_to_group(username, groupname, role)
-
-    def disable_user(self, username):
+    def disable_user(self, name):
         # type: (str) -> None
-        user = SQLUser.get(self.session, name=username)
+        user = SQLUser.get(self.session, name=name)
         if not user:
-            raise UserNotFoundException(username)
+            raise UserNotFoundException(name)
 
         user.enabled = False
 
-    def enable_user(self, username):
-        # type: (str) -> None
-        user = SQLUser.get(self.session, name=username)
+    def user_is_enabled(self, name):
+        # type: (str) -> bool
+        user = SQLUser.get(self.session, name=name)
         if not user:
-            raise UserNotFoundException(username)
+            raise UserNotFoundException(name)
 
-        user.enabled = True
-
-    def groups_of_user(self, username):
-        # type: (str) -> List[str]
-        return self.group_edge_repository.groups_of_user(username)
-
-    def mark_disabled_user_as_service_account(self, username):
-        # type: (str) -> None
-        user = SQLUser.get(self.session, name=username)
-        if not user:
-            raise UserNotFoundException(username)
-
-        if self.groups_of_user(username) != []:
-            raise UserIsMemberOfGroupsException(username)
-
-        if self.group_request_repository.pending_requests_for_user(username) != []:
-            raise UserHasPendingRequestsException(username)
-
-        service_account = SQLServiceAccount(user_id=user.id)
-        service_account.add(self.session)
-
-        user.is_service_account = True
+        return user.enabled

--- a/grouper/repositories/user.py
+++ b/grouper/repositories/user.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from grouper.repositories.interfaces import GroupEdgeRepository
     from typing import List
 
+
 class UserIsMemberOfGroupsException(Exception):
     """Operation failed because user is a member of groups."""
 
@@ -20,6 +21,7 @@ class UserIsMemberOfGroupsException(Exception):
         msg = "User {} is a member of one or more groups".format(username)
         super(UserIsMemberOfGroupsException, self).__init__(msg)
 
+
 class UserHasPendingRequestsException(Exception):
     """Operation failed because user has pending requests."""
 
@@ -27,6 +29,7 @@ class UserHasPendingRequestsException(Exception):
         # type: (str) -> None
         msg = "User {} has one or more pending requests".format(username)
         super(UserHasPendingRequestsException, self).__init__(msg)
+
 
 class GraphUserRepository(UserRepository):
     """Graph-aware storage layer for users."""
@@ -55,6 +58,7 @@ class GraphUserRepository(UserRepository):
     def mark_disabled_user_as_service_account(self, username):
         # type: (str) -> None
         return self.repository.mark_disabled_user_as_service_account(username)
+
 
 class SQLUserRepository(UserRepository):
     """SQL storage layer for users."""
@@ -101,10 +105,7 @@ class SQLUserRepository(UserRepository):
         if self.group_request_repository.pending_requests_for_user(username) != []:
             raise UserHasPendingRequestsException(username)
 
-        service_account = SQLServiceAccount(
-            user_id=user.id,
-        )
+        service_account = SQLServiceAccount(user_id=user.id)
         service_account.add(self.session)
 
         user.is_service_account = True
-

--- a/grouper/repositories/user.py
+++ b/grouper/repositories/user.py
@@ -1,0 +1,43 @@
+from typing import TYPE_CHECKING
+
+from grouper.entities.user import UserNotFoundException
+from grouper.models.user import User as SQLUser
+from grouper.repositories.interfaces import UserRepository
+
+if TYPE_CHECKING:
+    from grouper.graph import GroupGraph
+
+class GraphUserRepository(UserRepository):
+    """Graph-aware storage layer for permissions."""
+
+    def __init__(self, graph, repository):
+        # type: (GroupGraph, UserRepository) -> None
+        self.graph = graph
+        self.repository = repository
+
+    def disable_user(self, user):
+        # type: (str) -> None
+        return self.repository.disable_user(user)
+
+    def groups_of_user(self, user):
+        # type: (str) -> List[str]
+        user_details = self.graph.get_user_details(user)
+        return [group["name"] for group in user_details["groups"]]
+
+class SQLUserRepository(UserRepository):
+    """SQL storage layer for users."""
+
+    def __init__(self, session):
+        # type: (Session) -> None
+        self.session = session
+
+    def disable_user(self, username):
+        # type: (str) -> None
+        user = SQLUser.get(session, name=username)
+        if not user:
+            raise UserNotFoundException(username)
+        user.enabled = False
+
+    def groups_of_user(self, user):
+        # type: (str) -> List[str]
+        raise NotImplementedError()

--- a/grouper/repositories/user.py
+++ b/grouper/repositories/user.py
@@ -6,23 +6,36 @@ from grouper.repositories.interfaces import UserRepository
 
 if TYPE_CHECKING:
     from grouper.graph import GroupGraph
+    from grouper.models.base.session import session
 
 class GraphUserRepository(UserRepository):
-    """Graph-aware storage layer for permissions."""
+    """Graph-aware storage layer for users."""
 
     def __init__(self, graph, repository):
         # type: (GroupGraph, UserRepository) -> None
         self.graph = graph
         self.repository = repository
 
-    def disable_user(self, user):
-        # type: (str) -> None
-        return self.repository.disable_user(user)
+    def add_user_to_group(self, username, groupname):
+        # type: (str, str) -> None
+        return self.repository.add_user_to_group(username, groupname)
 
-    def groups_of_user(self, user):
+    def disable_user(self, username):
+        # type: (str) -> None
+        return self.repository.disable_user(username)
+
+    def enable_user(self, username):
+        # type: (str) -> None
+        return self.repository.enable_user(username)
+
+    def groups_of_user(self, username):
         # type: (str) -> List[str]
-        user_details = self.graph.get_user_details(user)
+        user_details = self.graph.get_user_details(username)
         return [group["name"] for group in user_details["groups"]]
+
+    def mark_disabled_user_as_service_account(self, username):
+        # type: (str) -> None
+        return self.repository.mark_disabled_user_as_service_account(username)
 
 class SQLUserRepository(UserRepository):
     """SQL storage layer for users."""
@@ -31,6 +44,9 @@ class SQLUserRepository(UserRepository):
         # type: (Session) -> None
         self.session = session
 
+    def add_user_to_group(self, username, groupname):
+        # type: (str, str) -> None
+
     def disable_user(self, username):
         # type: (str) -> None
         user = SQLUser.get(session, name=username)
@@ -38,6 +54,20 @@ class SQLUserRepository(UserRepository):
             raise UserNotFoundException(username)
         user.enabled = False
 
-    def groups_of_user(self, user):
+    def enable_user(self, username):
+        # type: (str) -> None
+        user = SQLUser.get(session, name=username)
+        if not user:
+            raise UserNotFoundException(username)
+        user.enabled = True
+
+    def groups_of_user(self, username):
         # type: (str) -> List[str]
         raise NotImplementedError()
+
+    def mark_disabled_user_as_service_account(self, username):
+        # type: (str) -> None
+        user = SQLUser.get(session, name=username)
+        if not user:
+            raise UserNotFoundException(username)
+        user.is_service_account = True

--- a/grouper/services/audit_log.py
+++ b/grouper/services/audit_log.py
@@ -13,6 +13,15 @@ class AuditLogService(object):
         # type: (AuditLogRepository) -> None
         self.audit_log_repository = audit_log_repository
 
+    def log_create_service_account_from_disabled_user(self, user, authorization):
+        # type: (str, Authorization) -> None
+        self.audit_log_repository.log(
+            authorization=authorization,
+            action="create_service_account_from_disabled_user",
+            description="Convert a disabled user into a disabled service account",
+            on_user=user,
+        )
+
     def log_disable_permission(self, permission, authorization):
         # type: (str, Authorization) -> None
         self.audit_log_repository.log(
@@ -20,6 +29,25 @@ class AuditLogService(object):
             action="disable_permission",
             description="Disabled permission",
             on_permission=permission,
+        )
+
+    def log_disable_user(self, username, authorization):
+        # type: (str, Authorization) -> None
+        self.audit_log_repository.log(
+            authorization=authorization,
+            action="disable_user",
+            description="Disabled user",
+            on_user=username,
+        )
+
+    def log_enable_service_account(self, user, owner, authorization):
+        # type: (str, str, Authorization) -> None
+        self.audit_log_repository.log(
+            authorization=authorization,
+            action="enable_service_account",
+            description="Enabled service account",
+            on_user=user,
+            on_group=owner,
         )
 
     def log_user_group_request_status_change(self, request, status, authorization):

--- a/grouper/services/factory.py
+++ b/grouper/services/factory.py
@@ -45,10 +45,12 @@ class ServiceFactory(object):
         audit_log_service = AuditLogService(audit_log_repository)
         user_repository = self.repository_factory.create_user_repository()
         service_account_repository = self.repository_factory.create_service_account_repository()
+        group_edge_repository = self.repository_factory.create_group_edge_repository()
         group_request_repository = self.repository_factory.create_group_request_repository()
         return ServiceAccountService(
             user_repository,
             service_account_repository,
+            group_edge_repository,
             group_request_repository,
             audit_log_service,
         )
@@ -65,4 +67,7 @@ class ServiceFactory(object):
         audit_log_service = AuditLogService(audit_log_repository)
         user_repository = self.repository_factory.create_user_repository()
         permission_grant_repository = self.repository_factory.create_permission_grant_repository()
-        return UserService(user_repository, permission_grant_repository, audit_log_service)
+        group_edge_repository = self.repository_factory.create_group_edge_repository()
+        return UserService(
+            user_repository, permission_grant_repository, group_edge_repository, audit_log_service
+        )

--- a/grouper/services/factory.py
+++ b/grouper/services/factory.py
@@ -46,10 +46,12 @@ class ServiceFactory(object):
         user_repository = self.repository_factory.create_user_repository()
         service_account_repository = self.repository_factory.create_service_account_repository()
         group_request_repository = self.repository_factory.create_group_request_repository()
-        return ServiceAccountService(user_repository,
-                                     service_account_repository,
-                                     group_request_repository,
-                                     audit_log_service)
+        return ServiceAccountService(
+            user_repository,
+            service_account_repository,
+            group_request_repository,
+            audit_log_service,
+        )
 
     def create_transaction_service(self):
         # type: () -> TransactionInterface

--- a/grouper/services/factory.py
+++ b/grouper/services/factory.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 from grouper.services.audit_log import AuditLogService
 from grouper.services.group_request import GroupRequestService
 from grouper.services.permission import PermissionService
+from grouper.services.service_account import ServiceAccountService
 from grouper.services.transaction import TransactionService
 from grouper.services.user import UserService
 
@@ -11,6 +12,7 @@ if TYPE_CHECKING:
     from grouper.usecases.interfaces import (
         GroupRequestInterface,
         PermissionInterface,
+        ServiceAccountInterface,
         TransactionInterface,
         UserInterface,
     )
@@ -39,12 +41,15 @@ class ServiceFactory(object):
 
     def create_service_account_service(self):
         # type: () -> ServiceAccountInterface
-        user_repository = self.repository_factory.create_service_account_repository()
+        audit_log_repository = self.repository_factory.create_audit_log_repository()
+        audit_log_service = AuditLogService(audit_log_repository)
+        user_repository = self.repository_factory.create_user_repository()
         service_account_repository = self.repository_factory.create_service_account_repository()
         group_request_repository = self.repository_factory.create_group_request_repository()
         return ServiceAccountService(user_repository,
                                      service_account_repository,
-                                     group_request_repository)
+                                     group_request_repository,
+                                     audit_log_service)
 
     def create_transaction_service(self):
         # type: () -> TransactionInterface
@@ -54,6 +59,8 @@ class ServiceFactory(object):
 
     def create_user_service(self):
         # type: () -> UserInterface
+        audit_log_repository = self.repository_factory.create_audit_log_repository()
+        audit_log_service = AuditLogService(audit_log_repository)
         user_repository = self.repository_factory.create_user_repository()
         permission_grant_repository = self.repository_factory.create_permission_grant_repository()
-        return UserService(user_repository, permission_grant_repository)
+        return UserService(user_repository, permission_grant_repository, audit_log_service)

--- a/grouper/services/factory.py
+++ b/grouper/services/factory.py
@@ -39,8 +39,12 @@ class ServiceFactory(object):
 
     def create_service_account_service(self):
         # type: () -> ServiceAccountInterface
+        user_repository = self.repository_factory.create_service_account_repository()
         service_account_repository = self.repository_factory.create_service_account_repository()
-        return ServiceAccountService(service_account_repository)
+        group_request_repository = self.repository_factory.create_group_request_repository()
+        return ServiceAccountService(user_repository,
+                                     service_account_repository,
+                                     group_request_repository)
 
     def create_transaction_service(self):
         # type: () -> TransactionInterface

--- a/grouper/services/factory.py
+++ b/grouper/services/factory.py
@@ -37,6 +37,11 @@ class ServiceFactory(object):
         permission_repository = self.repository_factory.create_permission_repository()
         return PermissionService(audit_log_service, permission_repository)
 
+    def create_service_account_service(self):
+        # type: () -> ServiceAccountInterface
+        service_account_repository = self.repository_factory.create_service_account_repository()
+        return ServiceAccountService(service_account_repository)
+
     def create_transaction_service(self):
         # type: () -> TransactionInterface
         transaction_repository = self.repository_factory.create_transaction_repository()

--- a/grouper/services/service_account.py
+++ b/grouper/services/service_account.py
@@ -8,16 +8,17 @@ if TYPE_CHECKING:
     from grouper.services.audit_log import AuditLogService
     from grouper.usecases.authorization import Authorization
 
+
 class ServiceAccountService(ServiceAccountInterface):
     """High-level logic to manipulate service accounts."""
 
     def __init__(
-                    self,
-                    user_repository,  # type: UserRepository
-                    service_account_repository,  # type: ServiceAccountRepository
-                    group_request_repository,  # type: GroupRequestRepository
-                    audit_log_service,  # type: AuditLogService
-                ):
+        self,
+        user_repository,  # type: UserRepository
+        service_account_repository,  # type: ServiceAccountRepository
+        group_request_repository,  # type: GroupRequestRepository
+        audit_log_service,  # type: AuditLogService
+    ):
         # type: (...) -> None
         self.user_repository = user_repository
         self.service_account_repository = service_account_repository
@@ -26,8 +27,6 @@ class ServiceAccountService(ServiceAccountInterface):
 
     def create_service_account_from_disabled_user(self, user, authorization):
         # type: (str, Authorization) -> None
-        assert self.user_repository.groups_of_user(user) == []
-        assert self.group_request_repository.pending_requests_for_user(user) == [] # TODO(wrodriguez)
 
         # WARNING: This logic relies on the fact that the user and service account repos
         # are in fact the same thing, as it never explicitly removes the user from the

--- a/grouper/services/service_account.py
+++ b/grouper/services/service_account.py
@@ -1,10 +1,17 @@
 from typing import TYPE_CHECKING
 
+from grouper.entities.user import (
+    UserIsEnabledException,
+    UserIsMemberOfGroupsException,
+    UserHasPendingRequestsException,
+)
 from grouper.usecases.interfaces import ServiceAccountInterface
 
 if TYPE_CHECKING:
-    from grouper.repositories.interfaces import UserRepository, ServiceAccountRepository
+    from grouper.repositories.group_edge import GroupEdgeRepository
     from grouper.repositories.group_request import GroupRequestRepository
+    from grouper.repositories.service_account import ServiceAccountRepository
+    from grouper.repositories.user import UserRepository
     from grouper.services.audit_log import AuditLogService
     from grouper.usecases.authorization import Authorization
 
@@ -16,25 +23,31 @@ class ServiceAccountService(ServiceAccountInterface):
         self,
         user_repository,  # type: UserRepository
         service_account_repository,  # type: ServiceAccountRepository
+        group_edge_repository,  # type: GroupEdgeRepository
         group_request_repository,  # type: GroupRequestRepository
         audit_log_service,  # type: AuditLogService
     ):
         # type: (...) -> None
         self.user_repository = user_repository
         self.service_account_repository = service_account_repository
+        self.group_edge_repository = group_edge_repository
         self.group_request_repository = group_request_repository
         self.audit_log = audit_log_service
 
     def create_service_account_from_disabled_user(self, user, authorization):
         # type: (str, Authorization) -> None
+        if self.user_repository.user_is_enabled(user):
+            raise UserIsEnabledException(user)
+        if self.group_edge_repository.groups_of_user(user) != []:
+            raise UserIsMemberOfGroupsException(user)
+        if self.group_request_repository.pending_requests_for_user(user) != []:
+            raise UserHasPendingRequestsException(user)
 
         # WARNING: This logic relies on the fact that the user and service account repos
         # are in fact the same thing, as it never explicitly removes the user from the
         # user repo. This is a temporary breaking of the abstractions and will have to be
         # cleaned up once the repositories are properly separate.
-        self.user_repository.mark_disabled_user_as_service_account(user)
-        self.service_account_repository.set_service_account_description(user, "")
-        self.service_account_repository.set_service_account_mdbset(user, "")
+        self.service_account_repository.mark_disabled_user_as_service_account(user)
 
         self.audit_log.log_create_service_account_from_disabled_user(user, authorization)
 

--- a/grouper/services/service_account.py
+++ b/grouper/services/service_account.py
@@ -1,0 +1,29 @@
+from typing import TYPE_CHECKING
+
+from grouper.usecases.interfaces import ServiceAccountInterface
+
+if TYPE_CHECKING:
+    from grouper.repositories.interfaces import
+
+class ServiceAccountService(ServiceAccountInterface):
+    """High-level logic to manipulate service accounts."""
+
+    def __init__(self, service_account_repository):
+        # type: (ServiceAccountRepository) -> None
+        self.service_account_repository = service_account_repository
+
+    def create_service_account_from_disabled_user(self, user):
+        # type: (str) -> None
+        assert "user not in any groups"
+        assert "user has no pending reqs"
+
+        # WARNING: This logic relies on the fact that the user and service account repos
+        # are in fact the same thing, as it never explicitly removes the user from the
+        # user repo. This is a temporary breaking of the abstractions and will have to be
+        # cleaned up once the repositories are properly separate.
+        self.service_account_repository.mark_disabled_user_as_service_account(user)
+
+    def enable_service_account(self, user, owner):
+        # type: (str, str) -> None
+        self.service_account_repository.assign_service_account_to_group(user, owner)
+        self.service_account_repository.enable_service_account(user)

--- a/grouper/services/service_account.py
+++ b/grouper/services/service_account.py
@@ -3,25 +3,38 @@ from typing import TYPE_CHECKING
 from grouper.usecases.interfaces import ServiceAccountInterface
 
 if TYPE_CHECKING:
-    from grouper.repositories.interfaces import
+    from grouper.repositories.interfaces import UserRepository, ServiceAccountRepository
+    from grouper.repositories.group_request import GroupRequestRepository
+    from grouper.services.audit_log import AuditLogService
 
 class ServiceAccountService(ServiceAccountInterface):
     """High-level logic to manipulate service accounts."""
 
-    def __init__(self, service_account_repository):
-        # type: (ServiceAccountRepository) -> None
+    def __init__(
+                    self,
+                    user_repository,  # type: UserRepository
+                    service_account_repository,  # type: ServiceAccountRepository
+                    group_request_repository,  # type: GroupRequestRepository
+                    audit_log_service,  # type: AuditLogService
+                ):
+        # type: (...) -> None
+        self.user_repository = user_repository
         self.service_account_repository = service_account_repository
+        self.group_request_repository = group_request_repository
+        self.audit_log = audit_log_service
 
     def create_service_account_from_disabled_user(self, user):
         # type: (str) -> None
-        assert "user not in any groups"
-        assert "user has no pending reqs"
+        assert self.user_repository.groups_of_user(user) == []
+        assert self.group_request_repository.pending_requests_for_user(user) == []
 
         # WARNING: This logic relies on the fact that the user and service account repos
         # are in fact the same thing, as it never explicitly removes the user from the
         # user repo. This is a temporary breaking of the abstractions and will have to be
         # cleaned up once the repositories are properly separate.
-        self.service_account_repository.mark_disabled_user_as_service_account(user)
+        self.user_repository.mark_disabled_user_as_service_account(user)
+        self.service_account_repository.set_service_account_description(user, "")
+        self.service_account_repository.set_service_account_mdbset(user, "")
 
     def enable_service_account(self, user, owner):
         # type: (str, str) -> None

--- a/grouper/services/service_account.py
+++ b/grouper/services/service_account.py
@@ -27,7 +27,7 @@ class ServiceAccountService(ServiceAccountInterface):
     def create_service_account_from_disabled_user(self, user, authorization):
         # type: (str, Authorization) -> None
         assert self.user_repository.groups_of_user(user) == []
-        assert self.group_request_repository.pending_requests_for_user(user) == []
+        assert self.group_request_repository.pending_requests_for_user(user) == [] # TODO(wrodriguez)
 
         # WARNING: This logic relies on the fact that the user and service account repos
         # are in fact the same thing, as it never explicitly removes the user from the

--- a/grouper/services/user.py
+++ b/grouper/services/user.py
@@ -6,16 +6,18 @@ from grouper.usecases.interfaces import UserInterface
 if TYPE_CHECKING:
     from grouper.repositories.interfaces import PermissionGrantRepository
     from grouper.repositories.user import UserRepository
+    from grouper.services.audit_log import AuditLogService
     from typing import List
 
 
 class UserService(UserInterface):
     """High-level logic to manipulate users."""
 
-    def __init__(self, user_repository, permission_grant_repository):
-        # type: (UserRepository, PermissionGrantRepository) -> None
+    def __init__(self, user_repository, permission_grant_repository, audit_log_service):
+        # type: (UserRepository, PermissionGrantRepository, AuditLogService) -> None
         self.user_repository = user_repository
         self.permission_grant_repository = permission_grant_repository
+        self.audit_log = audit_log_service
 
     def disable_user(self, user):
         # type: (str) -> None

--- a/grouper/services/user.py
+++ b/grouper/services/user.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
     from grouper.repositories.interfaces import PermissionGrantRepository
     from grouper.repositories.user import UserRepository
     from grouper.services.audit_log import AuditLogService
+    from grouper.usecases.authorization import Authorization
     from typing import List
 
 
@@ -19,9 +20,10 @@ class UserService(UserInterface):
         self.permission_grant_repository = permission_grant_repository
         self.audit_log = audit_log_service
 
-    def disable_user(self, user):
-        # type: (str) -> None
-        return self.user_repository.disable_user(user)
+    def disable_user(self, user, authorization):
+        # type: (str, Authorization) -> None
+        self.user_repository.disable_user(user)
+        self.audit_log.log_disable_user(user, authorization)
 
     def groups_of_user(self, user):
         # type: (str) -> List[str]

--- a/grouper/services/user.py
+++ b/grouper/services/user.py
@@ -4,6 +4,7 @@ from grouper.constants import PERMISSION_ADMIN, PERMISSION_CREATE, USER_ADMIN
 from grouper.usecases.interfaces import UserInterface
 
 if TYPE_CHECKING:
+    from grouper.repositories.group_edge import GroupEdgeRepository
     from grouper.repositories.interfaces import PermissionGrantRepository
     from grouper.repositories.user import UserRepository
     from grouper.services.audit_log import AuditLogService
@@ -14,10 +15,17 @@ if TYPE_CHECKING:
 class UserService(UserInterface):
     """High-level logic to manipulate users."""
 
-    def __init__(self, user_repository, permission_grant_repository, audit_log_service):
-        # type: (UserRepository, PermissionGrantRepository, AuditLogService) -> None
+    def __init__(
+        self,
+        user_repository,  # type: UserRepository
+        permission_grant_repository,  # type: PermissionGrantRepository
+        group_edge_repository,  # type: GroupEdgeRepository
+        audit_log_service,  # type: AuditLogService
+    ):
+        # type: (...) -> None
         self.user_repository = user_repository
         self.permission_grant_repository = permission_grant_repository
+        self.group_edge_repository = group_edge_repository
         self.audit_log = audit_log_service
 
     def disable_user(self, user, authorization):
@@ -27,7 +35,7 @@ class UserService(UserInterface):
 
     def groups_of_user(self, user):
         # type: (str) -> List[str]
-        return self.user_repository.groups_of_user(user)
+        return self.group_edge_repository.groups_of_user(user)
 
     def user_is_permission_admin(self, user):
         # type: (str) -> bool

--- a/grouper/usecases/convert_user_to_service_account.py
+++ b/grouper/usecases/convert_user_to_service_account.py
@@ -69,6 +69,8 @@ class ConvertUserToServiceAccount(object):
                     user, "User converted to service account", authorization
                 )
                 self.user_service.disable_user(user, authorization)
-                self.service_account_service.create_service_account_from_disabled_user(user, authorization)
+                self.service_account_service.create_service_account_from_disabled_user(
+                    user, authorization
+                )
                 self.service_account_service.enable_service_account(user, owner, authorization)
             self.ui.converted_user_to_service_account(user, owner)

--- a/grouper/usecases/convert_user_to_service_account.py
+++ b/grouper/usecases/convert_user_to_service_account.py
@@ -68,7 +68,7 @@ class ConvertUserToServiceAccount(object):
                 self.group_request_service.cancel_all_requests_for_user(
                     user, "User converted to service account", authorization
                 )
-                self.user_service.disable_user(user)
-                self.service_account_service.create_service_account_from_disabled_user(user)
-                self.service_account_service.enable_service_account(user, owner)
+                self.user_service.disable_user(user, authorization)
+                self.service_account_service.create_service_account_from_disabled_user(user, authorization)
+                self.service_account_service.enable_service_account(user, owner, authorization)
             self.ui.converted_user_to_service_account(user, owner)

--- a/grouper/usecases/interfaces.py
+++ b/grouper/usecases/interfaces.py
@@ -60,13 +60,13 @@ class ServiceAccountInterface(object):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def create_service_account_from_disabled_user(self, user):
-        # type: (str) -> None
+    def create_service_account_from_disabled_user(self, user, authorization):
+        # type: (str, Authorization) -> None
         pass
 
     @abstractmethod
-    def enable_service_account(self, user, owner):
-        # type: (str, str) -> None
+    def enable_service_account(self, user, owner, authorization):
+        # type: (str, str, Authorization) -> None
         pass
 
 
@@ -86,8 +86,8 @@ class UserInterface(object):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def disable_user(self, user):
-        # type: (str) -> None
+    def disable_user(self, user, authorization):
+        # type: (str, Authorization) -> None
         pass
 
     @abstractmethod

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -147,3 +147,20 @@ class SetupTest(object):
             permission_id=permission_obj.id, group_id=group_obj.id, argument=argument
         )
         grant.add(self.session)
+
+    def create_group_request(self, user, group, role="member"):
+        # type: (str, str, str) -> None
+        self.create_user(user)
+        self.create_group(group)
+
+        user_obj = User.get(self.session, name=user)
+        assert user_obj
+        group_obj = Group.get(self.session, name=group)
+        assert group_obj
+
+        group_obj.add_member(
+            requester=user_obj,
+            user_or_group=user_obj,
+            reason="",
+            role=role
+        )

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -158,9 +158,4 @@ class SetupTest(object):
         group_obj = Group.get(self.session, name=group)
         assert group_obj
 
-        group_obj.add_member(
-            requester=user_obj,
-            user_or_group=user_obj,
-            reason="",
-            role=role
-        )
+        group_obj.add_member(requester=user_obj, user_or_group=user_obj, reason="", role=role)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -158,4 +158,8 @@ class SetupTest(object):
         group_obj = Group.get(self.session, name=group)
         assert group_obj
 
-        group_obj.add_member(requester=user_obj, user_or_group=user_obj, reason="", role=role)
+        # Note: despite the function name, this only creates the request. The flow here is
+        # convoluted enough that it seems best to preserve exact behavior for testing.
+        group_obj.add_member(
+            requester=user_obj, user_or_group=user_obj, reason="", status="pending", role=role
+        )

--- a/tests/usecases/convert_user_to_service_account_test.py
+++ b/tests/usecases/convert_user_to_service_account_test.py
@@ -3,6 +3,9 @@ from typing import TYPE_CHECKING
 from mock import call, MagicMock
 
 from grouper.constants import USER_ADMIN
+from grouper.models.group import Group
+from grouper.models.group_service_accounts import GroupServiceAccount
+from grouper.models.service_account import ServiceAccount
 from grouper.models.user import User
 
 if TYPE_CHECKING:
@@ -27,4 +30,17 @@ def test_success(setup):
     service_account_user = User.get(setup.session, name="service@a.co")
     assert service_account_user
     assert service_account_user.is_service_account
-    assert service_account_user.service_account.owner.groupname == "some-group"
+    assert service_account_user.enabled
+
+    service_account = ServiceAccount.get(setup.session, name="service@a.co")
+    assert service_account
+    assert service_account.description == ""
+    assert service_account.machine_set == ""
+
+    group = Group.get(setup.session, name="some-group")
+    group_service_account = GroupServiceAccount.get(
+        setup.session,
+        service_account_id=service_account.id)
+    assert group
+    assert group_service_account
+    assert group_service_account.group_id == group.id

--- a/tests/usecases/convert_user_to_service_account_test.py
+++ b/tests/usecases/convert_user_to_service_account_test.py
@@ -43,6 +43,7 @@ def test_success(setup):
     assert service_account
     assert service_account.description == ""
     assert service_account.machine_set == ""
+    assert service_account.user_id == service_account_user.id
 
     # Check that the ServiceAccount is owned by the correct Group
     group = Group.get(setup.session, name="some-group")

--- a/tests/usecases/convert_user_to_service_account_test.py
+++ b/tests/usecases/convert_user_to_service_account_test.py
@@ -47,11 +47,12 @@ def test_success(setup):
     # Check that the ServiceAccount is owned by the correct Group
     group = Group.get(setup.session, name="some-group")
     group_service_account = GroupServiceAccount.get(
-        setup.session,
-        service_account_id=service_account.id)
+        setup.session, service_account_id=service_account.id
+    )
     assert group
     assert group_service_account
     assert group_service_account.group_id == group.id
+
 
 def test_failed_access_denied(setup):
     # type: (SetupTest) -> None
@@ -69,6 +70,7 @@ def test_failed_access_denied(setup):
         call.convert_user_to_service_account_failed_permission_denied("service@a.co")
     ]
 
+
 def test_failed_member_of_group(setup):
     # type: (SetupTest) -> None
     setup.grant_permission_to_group(USER_ADMIN, "", "admins")
@@ -85,6 +87,7 @@ def test_failed_member_of_group(setup):
     assert mock_ui.mock_calls == [
         call.convert_user_to_service_account_failed_user_is_in_groups("service@a.co")
     ]
+
 
 def test_cancels_group_requests(setup):
     # type: (SetupTest) -> None
@@ -109,6 +112,7 @@ def test_cancels_group_requests(setup):
     assert count_requests_by_group(setup.session, group, status="cancelled") == 1
     assert count_requests_by_group(setup.session, group, status="pending") == 0
 
+
 def test_failed_user_does_not_exist(setup):
     # type: (SetupTest) -> None
     setup.grant_permission_to_group(USER_ADMIN, "", "admins")
@@ -121,6 +125,7 @@ def test_failed_user_does_not_exist(setup):
     )
     with pytest.raises(NoSuchUser):
         usecase.convert_user_to_service_account("dne@a.co", "some-group")
+
 
 def test_failed_group_does_not_exist(setup):
     # type: (SetupTest) -> None

--- a/tests/usecases/convert_user_to_service_account_test.py
+++ b/tests/usecases/convert_user_to_service_account_test.py
@@ -1,8 +1,12 @@
 from typing import TYPE_CHECKING
 
+import pytest
 from mock import call, MagicMock
 
 from grouper.constants import USER_ADMIN
+from grouper.entities.group import GroupNotFoundException
+from grouper.graph import NoSuchUser
+from grouper.group_requests import count_requests_by_group
 from grouper.models.group import Group
 from grouper.models.group_service_accounts import GroupServiceAccount
 from grouper.models.service_account import ServiceAccount
@@ -27,16 +31,20 @@ def test_success(setup):
     assert mock_ui.mock_calls == [
         call.converted_user_to_service_account("service@a.co", "some-group")
     ]
+
+    # Check the User after the conversion
     service_account_user = User.get(setup.session, name="service@a.co")
     assert service_account_user
     assert service_account_user.is_service_account
     assert service_account_user.enabled
 
+    # Check the ServiceAccount that should have been created
     service_account = ServiceAccount.get(setup.session, name="service@a.co")
     assert service_account
     assert service_account.description == ""
     assert service_account.machine_set == ""
 
+    # Check that the ServiceAccount is owned by the correct Group
     group = Group.get(setup.session, name="some-group")
     group_service_account = GroupServiceAccount.get(
         setup.session,
@@ -44,3 +52,85 @@ def test_success(setup):
     assert group
     assert group_service_account
     assert group_service_account.group_id == group.id
+
+def test_failed_access_denied(setup):
+    # type: (SetupTest) -> None
+    setup.add_user_to_group("gary@a.co", "admins")
+    setup.create_user("service@a.co")
+    setup.create_group("some-group")
+    setup.commit()
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_convert_user_to_service_account_usecase(
+        "gary@a.co", mock_ui
+    )
+
+    usecase.convert_user_to_service_account("service@a.co", "some-group")
+    assert mock_ui.mock_calls == [
+        call.convert_user_to_service_account_failed_permission_denied("service@a.co")
+    ]
+
+def test_failed_member_of_group(setup):
+    # type: (SetupTest) -> None
+    setup.grant_permission_to_group(USER_ADMIN, "", "admins")
+    setup.add_user_to_group("gary@a.co", "admins")
+    setup.create_user("service@a.co")
+    setup.add_user_to_group("service@a.co", "admins")
+    setup.create_group("some-group")
+    setup.commit()
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_convert_user_to_service_account_usecase(
+        "gary@a.co", mock_ui
+    )
+    usecase.convert_user_to_service_account("service@a.co", "some-group")
+    assert mock_ui.mock_calls == [
+        call.convert_user_to_service_account_failed_user_is_in_groups("service@a.co")
+    ]
+
+def test_cancels_group_requests(setup):
+    # type: (SetupTest) -> None
+    setup.grant_permission_to_group(USER_ADMIN, "", "admins")
+    setup.add_user_to_group("gary@a.co", "admins")
+    setup.create_user("service@a.co")
+    setup.create_group("some-group")
+    setup.create_group_request("service@a.co", "some-group")
+    setup.commit()
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_convert_user_to_service_account_usecase(
+        "gary@a.co", mock_ui
+    )
+    usecase.convert_user_to_service_account("service@a.co", "some-group")
+    assert mock_ui.mock_calls == [
+        call.converted_user_to_service_account("service@a.co", "some-group")
+    ]
+
+    # Confirm that the request to the group is now cancelled and there are no pending requests
+    group = Group.get(setup.session, name="some-group")
+    assert group
+    assert count_requests_by_group(setup.session, group, status="cancelled") == 1
+    assert count_requests_by_group(setup.session, group, status="pending") == 0
+
+def test_failed_user_does_not_exist(setup):
+    # type: (SetupTest) -> None
+    setup.grant_permission_to_group(USER_ADMIN, "", "admins")
+    setup.add_user_to_group("gary@a.co", "admins")
+    setup.create_group("some-group")
+    setup.commit()
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_convert_user_to_service_account_usecase(
+        "gary@a.co", mock_ui
+    )
+    with pytest.raises(NoSuchUser):
+        usecase.convert_user_to_service_account("dne@a.co", "some-group")
+
+def test_failed_group_does_not_exist(setup):
+    # type: (SetupTest) -> None
+    setup.grant_permission_to_group(USER_ADMIN, "", "admins")
+    setup.add_user_to_group("gary@a.co", "admins")
+    setup.create_user("service@a.co")
+    setup.commit()
+    mock_ui = MagicMock()
+    usecase = setup.usecase_factory.create_convert_user_to_service_account_usecase(
+        "gary@a.co", mock_ui
+    )
+    with pytest.raises(GroupNotFoundException):
+        usecase.convert_user_to_service_account("service@a.co", "some-group")


### PR DESCRIPTION
Remaining code for the `convert_user_to_service_account` usecase. Includes:
 - New service account service and repository.
 - New user repository.
 - New group edge repository.
 - New test cases.

And lots of other plumbing.

Notes/questions:

 - Starting to run into a bit of an issue of "repos use lots of other repos", which could later lead to circular dependencies. Not sure how to better segment things to avoid the issue, or if it's fine as is.

 - entities/ seems like a good place to plop exception definitions. I think my only exception (heh) to that is in the User repo, but can move those too if you agree.

 - In some places there is code structure that is now unnecessary because I changed approaches part way through; see for example the `add_user_to_group` functions. I figured might as well leave those in since guessing they'll be necessary later, but arguably should be removed for cleanliness.

 - Currently there's nothing testing edge case checking at levels below the usecase, so in particular nothing exercises the edge case checking code at the repo layer. Should that change?